### PR TITLE
Add pillow and scikit-learn to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pydantic
 python-multipart
 langchain
 openai
+pillow
+scikit-learn


### PR DESCRIPTION
## Summary
- include pillow and scikit-learn in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `./setup.sh` *(fails to install packages due to network restrictions)*
- `uvicorn app.api.main:app --host 0.0.0.0 --port 8000` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c91b5b6b08327a4a8e9c1c472002c

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/souvikroy/face-match/3)
<!-- Reviewable:end -->
